### PR TITLE
Fix example path

### DIFF
--- a/examples/adventure.rs
+++ b/examples/adventure.rs
@@ -5,5 +5,5 @@ use std::env;
 use orbgame::Game;
 
 fn main() {
-    Game::from_toml("res/adventure/game.toml").exec();
+    Game::from_toml("examples/adventure/game.toml").exec();
 }


### PR DESCRIPTION
Fixed the file path to make sure the example actually runs with `cargo run --example adventure`.