### PR TITLE
use Async flag for orbgame window

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -3,7 +3,9 @@ use std::time;
 
 use fps_counter::FPSCounter;
 
-use orbtk::{Rect, Window, WindowBuilder};
+use orbclient::WindowFlag;
+
+use orbtk::{Rect, Window, WindowBuilder };
 
 use super::{Scene, SceneConfig, ScriptEngine};
 
@@ -31,8 +33,9 @@ pub struct Game {
 impl Game {
     pub fn from_config(config: &GameConfig) -> Game {
         // todo: load theme css
-        let window_builder =
+        let mut window_builder =
             WindowBuilder::new(Rect::new(0, 0, config.width, config.height), &config.title);
+        window_builder = window_builder.flags(&[WindowFlag::Async]);
         let window = window_builder.build();
         let scene = Scene::from_config(&config.scene);
         window.add(&scene);


### PR DESCRIPTION
use Async flag for orbgame window, so animations are rendered (fix orbclient issue #41)